### PR TITLE
SOX-62101: Bugfix - reuse parent id in transactions

### DIFF
--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -38,10 +38,20 @@ class Transaction {
     this.parent = this.options.transaction;
     this.id = this.parent ? this.parent.id : generateTransactionId();
 
+    // Patch: partially mimics the “reuse” behavior in nested transactions, but reusing the parent transaction for all nested ones.
+    // Ref in docs: https://sequelize.org/docs/v7/querying/transactions/#nested-transactions
+    // Ref in code: https://github.com/sequelize/sequelize/blob/v7.0.0-alpha.44/packages/core/src/transaction.ts#L535
+    // This modification forces all nested transactions to share the root transaction’s identifier, so that every nested transaction is really just a savepoint in the same underlying connection. E.g. instead of getting its own unique ID, it “walks up” to the root and uses that ID for all nested transactions.
+
+    let rootTransaction = this;
+    while (rootTransaction.parent) {
+      rootTransaction = rootTransaction.parent;
+    }
+
     if (this.parent) {
-      this.id = this.parent.id;
-      this.parent.savepoints.push(this);
-      this.name = this.id + '-sp-' + this.parent.savepoints.length;
+      this.id = rootTransaction.id;
+      rootTransaction.savepoints.push(this);
+      this.name = this.id + '-sp-' + rootTransaction.savepoints.length;
     } else {
       this.id = this.name = generateTransactionId();
     }


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

JIRA: https://auditboard.atlassian.net/browse/SOX-62101

PR has been tested on API CI-CD here: https://github.com/soxhub/auditboard-backend/pull/23454

_related bugfix_: https://github.com/soxhub/sequelize/pull/30

# Bugfix: reuse parent id in all nested transactions

Issue: when created, a nested transaction attempts to use immediate parent's ID which leads to a savepoints dependent on different parents in stack, which produces a rollbacks that occurs at a place in the stack that's unexpected.

Bugfix goal: all savepoints in transactions are pushed onto the root transaction's savepoints array, thus ensuring that the savepoint markers are always in the right order.


## Related files / issues / docs

@jaswilli original discovery PR https://github.com/soxhub/auditboard-backend/pull/22355

https://github.com/sequelize/sequelize/issues/9770

https://sequelize.org/docs/v7/querying/transactions/#nested-transactions
https://github.com/sequelize/sequelize/blob/v7.0.0-alpha.44/packages/core/src/transaction.ts#L57

https://github.com/sequelize/sequelize/issues/8621
https://github.com/sequelize/sequelize/issues/11408

https://github.com/sequelize/sequelize/blob/v4.44.4/lib/transaction.js
https://github.com/sequelize/sequelize/blob/v4.44.4/lib/sequelize.js#L988

Related previous fixes:

https://github.com/soxhub/auditboard-backend/pull/11363/files

