### PR TITLE
SOX-62101: Bugfix - prevent transaction's parent .name override

### DIFF
--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -1395,10 +1395,18 @@ class QueryInterface {
       throw new Error('Unable to start a transaction without transaction object!');
     }
 
+    // Bugfix: prevent transaction's parent mutation (similar bugfix applied to rollbackTransaction)
+    // in original v4.44.4 we're mutating the parent's object always renaming
+    // transaction name by current name. In other words, if transaction.parent exists, its name will be
+    // overwritten by transaction.name -- altering the parent object.
+    // Here we fix that by cloning the parent, so we don't modify the original.
+    const transactionForOptions = transaction.parent ? _.assign({}, transaction.parent) : transaction;
     options = _.assign({}, options, {
-      transaction: transaction.parent || transaction
+      transaction: transactionForOptions
     });
-    options.transaction.name = transaction.parent ? transaction.name : undefined;
+    // Now we update the clone without affecting the original parent
+    transactionForOptions.name = transaction.parent ? transaction.name : undefined;
+
     const sql = this.QueryGenerator.startTransactionQuery(transaction);
 
     return this.sequelize.query(sql, options);
@@ -1445,11 +1453,19 @@ class QueryInterface {
       throw new Error('Unable to rollback a transaction without transaction object!');
     }
 
+    // Bugfix: prevent transaction's parent mutation (similar bugfix applied to startTransaction)
+    // in original v4.44.4 we're mutating the parent's object always renaming
+    // transaction name by current name. In other words, if transaction.parent exists, its name will be
+    // overwritten by transaction.name -- altering the parent object.
+    // Here we fix that by cloning the parent, so we don't modify the original.
+    const transactionForOptions = transaction.parent ? _.assign({}, transaction.parent) : transaction;
     options = _.assign({}, options, {
-      transaction: transaction.parent || transaction,
+      transaction: transactionForOptions,
       supportsSearchPath: false
     });
-    options.transaction.name = transaction.parent ? transaction.name : undefined;
+    // Now we update the clone without affecting the original parent
+    transactionForOptions.name = transaction.parent ? transaction.name : undefined;
+
     const sql = this.QueryGenerator.rollbackTransactionQuery(transaction);
     const promise = this.sequelize.query(sql, options);
 


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->
JIRA: https://auditboard.atlassian.net/browse/SOX-62101

_related bugfix_: https://github.com/soxhub/sequelize/pull/29

# Bugfix: prevent transaction's parent .name override

Issue: in original v4.44.4 sequelize/lib/query-interface.js functions [startTransaction](https://github.com/sequelize/sequelize/blob/v4.44.4/lib/query-interface.js#L1393) & [rollbackTransaction](https://github.com/sequelize/sequelize/blob/v4.44.4/lib/query-interface.js#L1452) we're mutating the parent's object always renaming transaction name by current name.
```js
    options = _.assign({}, options, {
      transaction: transaction.parent || transaction
    });
    options.transaction.name = transaction.parent ? transaction.name : undefined;
```
In other words, if transaction.parent exists, its name will be overwritten by transaction.name -- altering the parent object. This leads to a savepoint stack top and last CLS saved "transaction" to looks like this:
```js
{
  // ...
  id: 'd72b130e-ee11-4e93-b24c-c7d44ce8cdea',
  name: 'd72b130e-ee11-4e93-b24c-c7d44ce8cdea-sp-4',
  parentName: 'd72b130e-ee11-4e93-b24c-c7d44ce8cdea-sp-4'
  // ...
}
```
<img width="440" alt="image" src="https://github.com/user-attachments/assets/3377fa23-63f5-4335-a1c9-01dfb4562e73" />

Bugfix goal: we clone the parent transaction, so we don't modify the original one
